### PR TITLE
Fixed documentation for BusTracker instantiation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This gem allows you to access the Chicago Transit Authority API via Ruby. You ca
 require 'cta-api'
 
 key = "XXXXXXXXXXXXXXXXXXXXXXXXX"
-@tracker = CTA::TrainTracker.new(key)
+@tracker = CTA::BusTracker.new(key)
 ```
 
 ### Find Routes and Stops


### PR DESCRIPTION
Fixed documentation of instantiation for BusTracker. Documentation used TrainTracker class instead of BusTracker.
